### PR TITLE
Added exception details

### DIFF
--- a/source/Src/SemanticLogging.Etw.WindowsService/ParameterOptions.cs
+++ b/source/Src/SemanticLogging.Etw.WindowsService/ParameterOptions.cs
@@ -152,15 +152,6 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Service
                     Console.ReadLine();
                 }
             }
-            catch (ReflectionTypeLoadException rtle)
-            {
-                var loaderExceptions = rtle.LoaderExceptions;
-                foreach (var e in loaderExceptions)
-                {
-                    Console.WriteLine(e.ToString());
-                }
-                DisplayExceptionOnConsole(rtle);
-            }
             catch (Exception e)
             {
                 DisplayExceptionOnConsole(e);
@@ -192,11 +183,25 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Service
 
         private void DisplayExceptionOnConsole(Exception e)
         {
+            var rtle = e as ReflectionTypeLoadException;
+            if (rtle != null)
+            {
+                DisplayLoaderExceptionsOnConsole(rtle);
+            }
+
             Console.WriteLine(e.ToString());
             Console.WriteLine();
             Console.WriteLine(Resources.StopServiceMessage);
             Console.ReadLine();
             this.ExitCode = ApplicationExitCode.RuntimeError;
+        }
+
+        private static void DisplayLoaderExceptionsOnConsole(ReflectionTypeLoadException e)
+        {
+            foreach (var loaderException in e.LoaderExceptions)
+            {
+                Console.WriteLine(loaderException.ToString());
+            }
         }
 
         private bool IsAuthorized()

--- a/source/Src/SemanticLogging.Etw.WindowsService/ParameterOptions.cs
+++ b/source/Src/SemanticLogging.Etw.WindowsService/ParameterOptions.cs
@@ -152,13 +152,18 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Service
                     Console.ReadLine();
                 }
             }
+            catch (ReflectionTypeLoadException rtle)
+            {
+                var loaderExceptions = rtle.LoaderExceptions;
+                foreach (var e in loaderExceptions)
+                {
+                    Console.WriteLine(e.ToString());
+                }
+                DisplayExceptionOnConsole(rtle);
+            }
             catch (Exception e)
             {
-                Console.WriteLine(e.ToString());
-                Console.WriteLine();
-                Console.WriteLine(Resources.StopServiceMessage);
-                Console.ReadLine();
-                this.ExitCode = ApplicationExitCode.RuntimeError;
+                DisplayExceptionOnConsole(e);
             }
         }
 
@@ -183,6 +188,15 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Service
         private static ServiceController GetController()
         {
             return ServiceController.GetServices().FirstOrDefault(s => s.ServiceName.Equals(Constants.ServiceName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private void DisplayExceptionOnConsole(Exception e)
+        {
+            Console.WriteLine(e.ToString());
+            Console.WriteLine();
+            Console.WriteLine(Resources.StopServiceMessage);
+            Console.ReadLine();
+            this.ExitCode = ApplicationExitCode.RuntimeError;
         }
 
         private bool IsAuthorized()

--- a/source/Src/SemanticLogging.Etw.WindowsService/ParameterOptions.cs
+++ b/source/Src/SemanticLogging.Etw.WindowsService/ParameterOptions.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Service
             this.ExitCode = ApplicationExitCode.RuntimeError;
         }
 
-        private static void DisplayLoaderExceptionsOnConsole(ReflectionTypeLoadException e)
+        private void DisplayLoaderExceptionsOnConsole(ReflectionTypeLoadException e)
         {
             foreach (var loaderException in e.LoaderExceptions)
             {

--- a/source/Src/SemanticLogging.Etw.WindowsService/TraceEventServiceHost.cs
+++ b/source/Src/SemanticLogging.Etw.WindowsService/TraceEventServiceHost.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Configuration;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Service.Properties;
+using System.Reflection;
 
 namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Service
 {
@@ -73,7 +74,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Service
                 // log and rethrow to notify SCM
                 if (!this.consoleMode)
                 {
-                    this.EventLog.WriteEntry(e.ToString(), EventLogEntryType.Error);
+                    LogException(e);
                 }
 
                 throw;
@@ -331,6 +332,25 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Etw.Service
             else
             {
                 this.EventLog.WriteEntry(error.ToString(), EventLogEntryType.Error);
+            }
+        }
+
+        private void LogException(Exception e)
+        {
+            var rtle = e as ReflectionTypeLoadException;
+            if (rtle != null)
+            {
+                LogLoaderExceptions(rtle);
+            }
+
+            this.EventLog.WriteEntry(e.ToString(), EventLogEntryType.Error);
+        }
+
+        private void LogLoaderExceptions(ReflectionTypeLoadException e)
+        {
+            foreach (var loaderException in e.LoaderExceptions)
+            {
+                this.EventLog.WriteEntry(loaderException.ToString(), EventLogEntryType.Error);
             }
         }
     }


### PR DESCRIPTION
Added exception details when a ReflectionTypeLoadException is thrown in SemanticLogging-svc.exe in console mode.

This saves many hours of debugging versioning issues with libraries referenced by the semantic logging out of process service and libraries referenced in the configuration.
