### PR TITLE
Add .mailmap file to correct authors list

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Randy Levy <randy.levy@gmail.com> randylevy <v-ralevy@microsoft.com>


### PR DESCRIPTION
Use .mailmap file to fix incorrect authors username/email.  Only affects [shortlog](http://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html) but better than nothing. 