### PR TITLE
Added xml payload support for sql database sink

### DIFF
--- a/source/Src/SemanticLogging.Database/Configuration/SqlDatabaseSinkElement.cs
+++ b/source/Src/SemanticLogging.Database/Configuration/SqlDatabaseSinkElement.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Xml.Linq;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Observable;
+using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility;
 
 namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Configuration
@@ -24,6 +25,8 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Configuration
         {
             Guard.ArgumentNotNull(element, "element");
 
+            PayloadFormatting payloadFormatting = (PayloadFormatting)Enum.Parse(typeof(PayloadFormatting), (string)element.Attribute("payloadFormatting") ?? default(PayloadFormatting).ToString());
+
             var subject = new EventEntrySubject();
             subject.LogToSqlDatabase(
                 (string)element.Attribute("instanceName"),
@@ -32,7 +35,8 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Configuration
                 element.Attribute("bufferingIntervalInSeconds").ToTimeSpan(),
                 (int?)element.Attribute("bufferingCount") ?? Buffering.DefaultBufferingCount,
                 element.Attribute("bufferingFlushAllTimeoutInSeconds").ToTimeSpan() ?? Constants.DefaultBufferingFlushAllTimeout,
-                (int?)element.Attribute("maxBufferSize") ?? Buffering.DefaultMaxBufferSize);
+                (int?)element.Attribute("maxBufferSize") ?? Buffering.DefaultMaxBufferSize,
+                payloadFormatting);
 
             return subject;
         }

--- a/source/Src/SemanticLogging.Database/Scripts/CreateSemanticLoggingDatabaseObjectsXml.sql
+++ b/source/Src/SemanticLogging.Database/Scripts/CreateSemanticLoggingDatabaseObjectsXml.sql
@@ -1,0 +1,148 @@
+﻿SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TYPE TracesType AS TABLE
+(
+	[InstanceName] [nvarchar](1000),
+	[ProviderId] [uniqueidentifier],
+	[ProviderName] [nvarchar](500),
+	[EventId] [int],
+	[EventKeywords] [bigint],
+	[Level] [int],
+	[Opcode] [int],
+	[Task] [int],
+	[Timestamp] [datetimeoffset](7),
+	[Version] [int],
+	[FormattedMessage] [nvarchar](4000),
+	[Payload] [xml],
+	[ActivityId] [uniqueidentifier], 
+	[RelatedActivityId] [uniqueidentifier],
+	[ProcessId] [int],
+	[ThreadId] [int]
+);
+
+GO
+
+
+CREATE PROCEDURE [dbo].[WriteTrace]
+(
+	@InstanceName [nvarchar](1000),
+	@ProviderId [uniqueidentifier],
+	@ProviderName [nvarchar](500),
+	@EventId [int],
+	@EventKeywords [bigint],
+	@Level [int],
+	@Opcode [int],
+	@Task [int],
+	@Timestamp [datetimeoffset](7),
+	@Version [int],
+	@FormattedMessage [nvarchar](4000),
+	@Payload [xml],
+	@ActivityId [uniqueidentifier], 
+	@RelatedActivityId [uniqueidentifier],
+	@ProcessId [int],
+	@ThreadId [int],
+	@TraceId [bigint] OUTPUT
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+	INSERT INTO [Traces] (
+		[InstanceName],
+		[ProviderId],
+		[ProviderName],
+		[EventId],
+		[EventKeywords],
+		[Level],
+		[Opcode],
+		[Task],
+		[Timestamp],
+		[Version],
+		[FormattedMessage],
+		[Payload],
+		[ActivityId],
+		[RelatedActivityId],
+		[ProcessId],
+		[ThreadId]
+	)
+	VALUES (
+		@InstanceName,
+	    @ProviderId,
+	    @ProviderName,
+		@EventId,
+		@EventKeywords,
+		@Level,
+		@Opcode,
+		@Task,
+		@Timestamp,
+		@Version,
+		@FormattedMessage,
+		@Payload,
+		@ActivityId,
+		@RelatedActivityId,
+		@ProcessId,
+		@ThreadId)
+
+	SET @TraceId = @@IDENTITY
+	RETURN @TraceId
+END
+
+GO
+
+CREATE PROCEDURE [dbo].[WriteTraces]
+(
+  @InsertTraces TracesType READONLY
+)
+AS
+BEGIN
+  INSERT INTO [Traces] (
+		[InstanceName],
+		[ProviderId],
+		[ProviderName],
+		[EventId],
+		[EventKeywords],
+		[Level],
+		[Opcode],
+		[Task],
+		[Timestamp],
+		[Version],
+		[FormattedMessage],
+		[Payload],
+		[ActivityId],
+		[RelatedActivityId],
+		[ProcessId],
+		[ThreadId]
+	)
+  SELECT * FROM @InsertTraces;
+END
+
+GO
+CREATE TABLE [dbo].[Traces](
+	[id] [bigint] IDENTITY(1,1) NOT NULL,
+	[InstanceName] [nvarchar](1000) NOT NULL,
+	[ProviderId] [uniqueidentifier] NOT NULL,
+	[ProviderName] [nvarchar](500) NOT NULL,
+	[EventId] [int] NOT NULL,
+	[EventKeywords] [bigint] NOT NULL,
+	[Level] [int] NOT NULL,
+	[Opcode] [int] NOT NULL,
+	[Task] [int] NOT NULL,
+	[Timestamp] [datetimeoffset](7) NOT NULL,
+	[Version] [int] NOT NULL,
+	[FormattedMessage] [nvarchar](4000) NULL,
+	[Payload] [xml] NULL,
+	[ActivityId] [uniqueidentifier],
+	[RelatedActivityId] [uniqueidentifier],
+	[ProcessId] [int],
+	[ThreadId] [int],
+ CONSTRAINT [PK_Traces] PRIMARY KEY CLUSTERED 
+(
+	[id] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF)
+)
+
+GO
+

--- a/source/Src/SemanticLogging.Database/SemanticLogging.Database.csproj
+++ b/source/Src/SemanticLogging.Database/SemanticLogging.Database.csproj
@@ -54,6 +54,7 @@
     </Compile>
     <Compile Include="Configuration\SqlDatabaseSinkElement.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Sinks\PayloadFormatting.cs" />
     <Compile Include="Sinks\SqlDatabaseSink.cs" />
     <Compile Include="Utility\EventRecordDataReader.cs" />
     <Compile Include="SqlDatabaseLog.cs" />

--- a/source/Src/SemanticLogging.Database/SemanticLogging.Database.csproj
+++ b/source/Src/SemanticLogging.Database/SemanticLogging.Database.csproj
@@ -54,6 +54,9 @@
     </Compile>
     <Compile Include="Configuration\SqlDatabaseSinkElement.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <None Include="Scripts\CreateSemanticLoggingDatabaseObjectsXml.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <Compile Include="Sinks\PayloadFormatting.cs" />
     <Compile Include="Sinks\SqlDatabaseSink.cs" />
     <Compile Include="Utility\EventRecordDataReader.cs" />

--- a/source/Src/SemanticLogging.Database/SemanticLogging.Database.csproj
+++ b/source/Src/SemanticLogging.Database/SemanticLogging.Database.csproj
@@ -54,9 +54,6 @@
     </Compile>
     <Compile Include="Configuration\SqlDatabaseSinkElement.cs" />
     <Compile Include="GlobalSuppressions.cs" />
-    <None Include="Scripts\CreateSemanticLoggingDatabaseObjectsXml.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <Compile Include="Sinks\PayloadFormatting.cs" />
     <Compile Include="Sinks\SqlDatabaseSink.cs" />
     <Compile Include="Utility\EventRecordDataReader.cs" />
@@ -82,7 +79,11 @@
     <None Include="packages.config" />
     <None Include="SemanticLogging.Database.nuspec" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Scripts\CreateSemanticLoggingDatabaseObjectsXml.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <ItemGroup>
     <None Include="..\..\Scripts\CreateSemanticLoggingDatabase.sql">
       <Link>Scripts\CreateSemanticLoggingDatabase.sql</Link>

--- a/source/Src/SemanticLogging.Database/SemanticLogging.Database.nuspec
+++ b/source/Src/SemanticLogging.Database/SemanticLogging.Database.nuspec
@@ -25,6 +25,7 @@
     <file src="NuGet\Readme-Database.txt" target="Readme.txt" />
     <file src="scripts\CreateSemanticLoggingDatabase.sql" target="scripts" />
     <file src="scripts\CreateSemanticLoggingDatabaseObjects.sql" target="scripts" />
+	<file src="scripts\CreateSemanticLoggingDatabaseObjectsXml.sql" target="scripts" />
     <file src="scripts\CreateSemanticLoggingDb.cmd" target="scripts" />
   </files>
 </package>

--- a/source/Src/SemanticLogging.Database/Sinks/PayloadFormatting.cs
+++ b/source/Src/SemanticLogging.Database/Sinks/PayloadFormatting.cs
@@ -1,0 +1,18 @@
+namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
+{
+    /// <summary>
+    /// Defines the formatting of the payload data.
+    /// </summary>
+    public enum PayloadFormatting
+    {
+        /// <summary>
+        /// Json Formatting.
+        /// </summary>
+        Json,
+
+        /// <summary>
+        /// Xml Formatting.
+        /// </summary>
+        Xml
+    }
+}

--- a/source/Src/SemanticLogging.Database/Sinks/PayloadFormatting.cs
+++ b/source/Src/SemanticLogging.Database/Sinks/PayloadFormatting.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
 {
     /// <summary>
@@ -8,6 +10,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
         /// <summary>
         /// Json Formatting.
         /// </summary>
+        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "Needs Review.")]
         Json,
 
         /// <summary>

--- a/source/Src/SemanticLogging.Database/SqlDatabaseLog.cs
+++ b/source/Src/SemanticLogging.Database/SqlDatabaseLog.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
         /// This means that if the timeout period elapses, some event entries will be dropped and not sent to the store. Normally, calling <see cref="IDisposable.Dispose" /> on
         /// the <see cref="System.Diagnostics.Tracing.EventListener" /> will block until all the entries are flushed or the interval elapses.
         /// If <see langword="null" /> is specified, then the call will block indefinitely until the flush operation finishes.</param>
+        /// <param name="payloadFormatting">The formatting of the payload data.</param>
         /// <returns>A subscription to the sink that can be disposed to unsubscribe the sink and dispose it, or to get access to the sink instance.</returns>
-        public static SinkSubscription<SqlDatabaseSink> LogToSqlDatabase(this IObservable<EventEntry> eventStream, string instanceName, string connectionString, string tableName = DefaultTableName, TimeSpan? bufferingInterval = null, int bufferingCount = Buffering.DefaultBufferingCount, TimeSpan? onCompletedTimeout = null, int maxBufferSize = Buffering.DefaultMaxBufferSize)
+        public static SinkSubscription<SqlDatabaseSink> LogToSqlDatabase(this IObservable<EventEntry> eventStream, string instanceName, string connectionString, string tableName = DefaultTableName, TimeSpan? bufferingInterval = null, int bufferingCount = Buffering.DefaultBufferingCount, TimeSpan? onCompletedTimeout = null, int maxBufferSize = Buffering.DefaultMaxBufferSize, PayloadFormatting payloadFormatting = PayloadFormatting.Json)
         {
             var sink = new SqlDatabaseSink(
                 instanceName,
@@ -45,7 +46,8 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
                 bufferingInterval ?? Buffering.DefaultBufferingInterval,
                 bufferingCount,
                 maxBufferSize,
-                onCompletedTimeout ?? Timeout.InfiniteTimeSpan);
+                onCompletedTimeout ?? Timeout.InfiniteTimeSpan,
+                payloadFormatting);
 
             var subscription = eventStream.Subscribe(sink);
 
@@ -68,11 +70,12 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
         /// This means that if the timeout period elapses, some event entries will be dropped and not sent to the store. Normally, calling <see cref="IDisposable.Dispose" /> on
         /// the <see cref="System.Diagnostics.Tracing.EventListener" /> will block until all the entries are flushed or the interval elapses.
         /// If <see langword="null" /> is specified, then the call will block indefinitely until the flush operation finishes.</param>
+        /// <param name="payloadFormatting">The formatting of the payload data.</param>
         /// <returns>An event listener that uses <see cref="SqlDatabaseSink"/> to log events.</returns>
-        public static EventListener CreateListener(string instanceName, string connectionString, string tableName = DefaultTableName, TimeSpan? bufferingInterval = null, int bufferingCount = Buffering.DefaultBufferingCount, TimeSpan? listenerDisposeTimeout = null, int maxBufferSize = Buffering.DefaultMaxBufferSize)
+        public static EventListener CreateListener(string instanceName, string connectionString, string tableName = DefaultTableName, TimeSpan? bufferingInterval = null, int bufferingCount = Buffering.DefaultBufferingCount, TimeSpan? listenerDisposeTimeout = null, int maxBufferSize = Buffering.DefaultMaxBufferSize, PayloadFormatting payloadFormatting = PayloadFormatting.Json)
         {
             var listener = new ObservableEventListener();
-            listener.LogToSqlDatabase(instanceName, connectionString, tableName, bufferingInterval, bufferingCount, listenerDisposeTimeout, maxBufferSize);
+            listener.LogToSqlDatabase(instanceName, connectionString, tableName, bufferingInterval, bufferingCount, listenerDisposeTimeout, maxBufferSize, payloadFormatting);
             return listener;
         }
     }

--- a/source/Src/SemanticLogging.Database/Utility/EventEntryExtensions.cs
+++ b/source/Src/SemanticLogging.Database/Utility/EventEntryExtensions.cs
@@ -19,11 +19,6 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Database.Utility
 
         internal static void BuildSqlMetaData(PayloadFormatting payloadFormatting)
         {
-            if (SqlMetaData != null)
-            {
-                return;
-            }
-
             var payloadMetaData = payloadFormatting == PayloadFormatting.Json
                 ? new SqlMetaData("Payload", SqlDbType.NVarChar, 4000)
                 : new SqlMetaData("Payload", SqlDbType.Xml);
@@ -53,8 +48,6 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Database.Utility
 
         internal static SqlDataRecord ToSqlDataRecord(this EventEntry record, string instanceName, PayloadFormatting payloadFormatting)
         {
-            BuildSqlMetaData(payloadFormatting);
-
             var sqlDataRecord = new SqlDataRecord(SqlMetaData);
             var payloadValue = payloadFormatting == PayloadFormatting.Json
                 ? EventEntryUtil.JsonSerializePayload(record)

--- a/source/Src/SemanticLogging.Database/Utility/EventEntryExtensions.cs
+++ b/source/Src/SemanticLogging.Database/Utility/EventEntryExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Data;
 using System.Linq;
+using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility;
 using Microsoft.SqlServer.Server;
 
@@ -41,7 +42,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Database.Utility
             Fields = SqlMetaData.Select(x => x.Name).ToArray();
         }
 
-        internal static SqlDataRecord ToSqlDataRecord(this EventEntry record, string instanceName)
+        internal static SqlDataRecord ToSqlDataRecord(this EventEntry record, string instanceName, PayloadFormatting payloadFormatting)
         {
             var sqlDataRecord = new SqlDataRecord(SqlMetaData);
 
@@ -56,7 +57,12 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Database.Utility
             sqlDataRecord.SetValue(8, record.Timestamp);
             sqlDataRecord.SetValue(9, record.Schema.Version);
             sqlDataRecord.SetValue(10, (object)record.FormattedMessage ?? DBNull.Value);
-            sqlDataRecord.SetValue(11, (object)EventEntryUtil.JsonSerializePayload(record) ?? DBNull.Value);
+
+            if(payloadFormatting == PayloadFormatting.Json)
+                sqlDataRecord.SetValue(11, (object)EventEntryUtil.JsonSerializePayload(record) ?? DBNull.Value);
+            else
+                sqlDataRecord.SetValue(11, (object)EventEntryUtil.XmlSerializePayload(record) ?? DBNull.Value);
+
             sqlDataRecord.SetValue(12, record.ActivityId);
             sqlDataRecord.SetValue(13, record.RelatedActivityId);
             sqlDataRecord.SetValue(14, record.ProcessId);

--- a/source/Src/SemanticLogging.Database/Utility/EventRecordDataReader.cs
+++ b/source/Src/SemanticLogging.Database/Utility/EventRecordDataReader.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Database.Utility
             this.enumerator = collection.GetEnumerator();
             this.instanceName = instanceName;
             this.payloadFormatting = payloadFormatting;
+
+            EventEntryExtensions.BuildSqlMetaData(payloadFormatting);
         }
 
         #region IDataReader

--- a/source/Src/SemanticLogging.Database/Utility/EventRecordDataReader.cs
+++ b/source/Src/SemanticLogging.Database/Utility/EventRecordDataReader.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks;
 using Microsoft.SqlServer.Server;
 
 namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Database.Utility
@@ -10,14 +11,16 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Database.Utility
     internal sealed class EventEntryDataReader : IDataReader, IConvertible
     {
         private readonly string instanceName;
+        private readonly PayloadFormatting payloadFormatting;
         private IEnumerator<EventEntry> enumerator;
         private int recordsAffected;
         private SqlDataRecord currentRecord;
 
-        public EventEntryDataReader(IEnumerable<EventEntry> collection, string instanceName)
+        public EventEntryDataReader(IEnumerable<EventEntry> collection, string instanceName, PayloadFormatting payloadFormatting)
         {
             this.enumerator = collection.GetEnumerator();
             this.instanceName = instanceName;
+            this.payloadFormatting = payloadFormatting;
         }
 
         #region IDataReader
@@ -92,7 +95,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Database.Utility
             if (result)
             {
                 this.recordsAffected++;
-                this.currentRecord = this.enumerator.Current.ToSqlDataRecord(this.instanceName);
+                this.currentRecord = this.enumerator.Current.ToSqlDataRecord(this.instanceName, this.payloadFormatting);
             }
 
             return result;
@@ -288,7 +291,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Database.Utility
 
             while (this.enumerator.MoveNext())
             {
-                list.Add(this.enumerator.Current.ToSqlDataRecord(this.instanceName));
+                list.Add(this.enumerator.Current.ToSqlDataRecord(this.instanceName, this.payloadFormatting));
             }
 
             this.enumerator.Reset();

--- a/source/Src/SemanticLogging/Formatters/XmlEventTextFormatter.cs
+++ b/source/Src/SemanticLogging/Formatters/XmlEventTextFormatter.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Formatters
 
                     if (entry.Payload[i] != null)
                     {
-                        SanitizeAndWritePayload(entry.Payload[i], writer);
+                        writer.WriteValue(EventEntryUtil.SanitizeXml(entry.Payload[i]));
                     }
 
                     writer.WriteEndElement();
@@ -177,23 +177,6 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Formatters
                     // We are in Error state so abort the write operation
                     throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Properties.Resources.XmlSerializationError, e.Message), e);
                 }
-            }
-        }
-
-        private static void SanitizeAndWritePayload(object value, XmlWriter writer)
-        {
-            var valueType = value.GetType();
-            if (valueType == typeof(Guid))
-            {
-                writer.WriteValue(XmlConvert.ToString((Guid)value));
-            }
-            else if (valueType.IsEnum)
-            {
-                writer.WriteValue(((Enum)value).ToString("D"));
-            }
-            else
-            {
-                writer.WriteValue(value);
             }
         }
     }

--- a/source/Src/SemanticLogging/Utility/EventEntryUtil.cs
+++ b/source/Src/SemanticLogging/Utility/EventEntryUtil.cs
@@ -4,6 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text;
+using System.Xml;
+using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Formatters;
 using Newtonsoft.Json;
 
 namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility
@@ -104,6 +107,75 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility
                 throw new InvalidOperationException(
                     string.Format(CultureInfo.CurrentCulture, Properties.Resources.JsonSerializationError, jwe.Message), jwe);
             }
+        }
+        internal static string XmlSerializePayload(EventEntry entry)
+        {
+            try
+            {
+                var settings = new XmlWriterSettings()
+                {
+                    OmitXmlDeclaration = true   // Do not add xml declaration
+                };
+
+                var writer = new StringBuilder();
+                using (var xmlWriter = XmlWriter.Create(writer, settings))
+                {
+                    EventEntryUtil.XmlWritePayload(xmlWriter, entry);
+                    xmlWriter.Flush();
+                    return writer.ToString();
+                }
+            }
+            catch (Exception e)
+            {
+                SemanticLoggingEventSource.Log.EventEntrySerializePayloadFailed(e.ToString());
+
+                return string.Format("<Error>{0}</Error>", string.Format(CultureInfo.CurrentCulture, Properties.Resources.XmlSerializationError, e.Message));
+            }
+        }
+
+        internal static void XmlWritePayload(XmlWriter writer, EventEntry entry)
+        {
+            writer.WriteStartElement("Payload");
+
+            var eventSchema = entry.Schema;
+
+            for (int i = 0; i < entry.Payload.Count; i++)
+            {
+                XmlWriteProperty(writer, eventSchema.Payload[i], entry.Payload[i]);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void XmlWriteProperty(XmlWriter writer, string propertyName, object value)
+        {
+            try
+            {
+                writer.WriteElementString(propertyName, SanitizeXml(value));
+            }
+            catch (Exception e)
+            {
+                SemanticLoggingEventSource.Log.EventEntryXmlWriterFailed(e.ToString());
+
+                // We are in Error state so abort the write operation
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Properties.Resources.XmlSerializationError, e.Message), e);
+            }
+        }
+
+        internal static string SanitizeXml(object value)
+        {
+            var valueType = value.GetType();
+            if (valueType == typeof(Guid))
+            {
+                return XmlConvert.ToString((Guid) value);
+            }
+
+            if (valueType.IsEnum)
+            {
+                return ((Enum)value).ToString("D");
+            }
+
+            return value.ToString();
         }
     }
 }


### PR DESCRIPTION
Added xml payload support for sql database sink. if configured to use xml as payload formatting then the data is stored in an xml column what makes for far more easier querying. I've provided the script that creates the xml based database objects.