### PR TITLE
Fixed typo that was causing SemanticLoggingEventSourceFixture.ShouldValidateEventSource test failures

### DIFF
--- a/source/Src/SemanticLogging/SemanticLoggingEventSource.cs
+++ b/source/Src/SemanticLogging/SemanticLoggingEventSource.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
         {
             if (this.IsEnabled())
             {
-                this.WriteEvent(903, providerName, eventId, message);
+                this.WriteEvent(1000, providerName, eventId, message);
             }
         }
 


### PR DESCRIPTION
Made `eventId` argument value in `ParsingEventSourceManifestFailed` method to be the same as declared in `Event` attribute.