### PR TITLE
Improve build script

### DIFF
--- a/source/NuGet/install-packages.ps1
+++ b/source/NuGet/install-packages.ps1
@@ -102,19 +102,22 @@ for($i=0; $i -lt $solutionFolders.Length; $i++)
     
     foreach ($dependency in $dependencies)
     {
-        Get-ChildItem -Recurse | Where { $_.FullName -like $dependency } | Copy-Item -Destination $scriptPath
+        Get-ChildItem $packgagedFolder -Recurse | Where { $_.FullName -like $dependency } | Copy-Item -Destination $scriptPath
     }
 
     popd
 }
 
-Write-Host "
+if (-not $autoAcceptTerms)
+{
+    Write-Host "
 You can now edit the configuration file to log events from your own application by opening 'SemanticLogging-svc.xml'.
 To get IntelliSense from the XML schema file, you can open the configuration in Microsoft Visual Studio.
 After the configuration is updated, start the Windows service by executing 'SemanticLogging-svc.exe -start' from an elevated command prompt.
 
 Press ENTER key to finish..."
-$x = $host.UI.ReadLine()
+    $x = $host.UI.ReadLine()
+}
 # SIG # Begin signature block
 # MIIatwYJKoZIhvcNAQcCoIIaqDCCGqQCAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
 # gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR

--- a/source/NuGet/install-packages.ps1
+++ b/source/NuGet/install-packages.ps1
@@ -9,7 +9,8 @@
 # ==============================================================================
 
 param (
-    [switch] $autoAcceptTerms
+    [switch] $autoAcceptTerms,
+    [string] $packagesFolder="packages"
 )
 
 # list all the solution folders where the "packages" folder will be placed.
@@ -81,7 +82,7 @@ for($i=0; $i -lt $solutionFolders.Length; $i++)
     pushd $solutionFolders[$i]
 
     # install the packages
-    $allPackagesFiles[$i] | ForEach-Object { & $nuget install $_.FullName -o packages }
+    $allPackagesFiles[$i] | ForEach-Object { & $nuget install $_.FullName -o $packagesFolder }
 
     $dependencies = @(
 		'*NET45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll',
@@ -102,7 +103,7 @@ for($i=0; $i -lt $solutionFolders.Length; $i++)
     
     foreach ($dependency in $dependencies)
     {
-        Get-ChildItem $packgagedFolder -Recurse | Where { $_.FullName -like $dependency } | Copy-Item -Destination $scriptPath
+        Get-ChildItem $packagesFolder -Recurse | Where { $_.FullName -like $dependency } | Copy-Item -Destination $scriptPath
     }
 
     popd


### PR DESCRIPTION
I'd like to improve semantic logging install package script. I fixed two issues because it's difficult to run the original script on a CI Server.

1) Skip ```ENTER Key``` when autoAcceptTerms is specified.
When I run this script on silent mode included running on CI server, I can't press ENTER key.

2) Specify nuget packages folder externally
There are some DLLs in dependent Nuget libraries whose path are too long to save due to the Windows' path length limitation.
So I'd like to specify the nuget packages folder externally.
```
PS> install-package.ps1 -autoAcceptTerms -packagedFolder  D:\tmp\packages
```