### PR TITLE
A few fixes to ES-MultiNode template

### DIFF
--- a/ES-MultiNode/azuredeploy-parameters.json
+++ b/ES-MultiNode/azuredeploy-parameters.json
@@ -9,7 +9,7 @@
         "value": "changeme"
     },
     "dataNodeCount": {
-        "value": "3"
+        "value": 3
     },
     "dataDiskSize": {
         "value":  "256"

--- a/ES-MultiNode/azuredeploy.json
+++ b/ES-MultiNode/azuredeploy.json
@@ -421,8 +421,8 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/kzadora/esdiagstore/master/es-ubuntu-install.sh",
-                        "https://raw.githubusercontent.com/kzadora/esdiagstore/master/vm-disk-utils-0.1.sh"
+                        "https://raw.githubusercontent.com/mspnp/semantic-logging/elk/ES-MultiNode/es-ubuntu-install.sh",
+                        "https://raw.githubusercontent.com/mspnp/semantic-logging/elk/ES-MultiNode/vm-disk-utils-0.1.sh"
                     ],
                     "commandToExecute": "[concat('bash es-ubuntu-install.sh ', ' -n ', parameters('esClusterName'), ' -d ', variables('dataNodesIpPrefix'), '4 -c ', parameters('dataNodeCount'), ' -v ', variables('esVersion'), ' -u ', parameters('esUserName'), ' -p ', parameters('esPassword'), ' -s ', variables('esClusterDnsName'))]"
                 }


### PR DESCRIPTION
1. One parameter value is stored as string in the sample parameters.json file, should be numeric
2. With the new repo location paths to ES setup scripts also need to change