### PR TITLE
Fixing Logstash Ruby scripts to make them work with new Azure SDK

### DIFF
--- a/ELK/logstash-extension/inputs/azureblob.rb
+++ b/ELK/logstash-extension/inputs/azureblob.rb
@@ -29,7 +29,7 @@ class LogStash::Inputs::Azureblob < LogStash::Inputs::Base
       config.storage_account_name = @storage_account_name
       config.storage_access_key = @storage_access_key
     end
-    @azure_blob = Azure::BlobService.new
+    @azure_blob = Azure::Blob::BlobService.new
   end # def register
   
   def list_blob_names

--- a/ELK/logstash-extension/inputs/azuretopic.rb
+++ b/ELK/logstash-extension/inputs/azuretopic.rb
@@ -29,7 +29,7 @@ class LogStash::Inputs::Azuretopic < LogStash::Inputs::Base
 	    config.sb_namespace = @namespace
 	    config.sb_access_key = @access_key
  	  end
-	@azure_service_bus = Azure::ServiceBusService.new
+	@azure_service_bus = Azure::ServiceBus::ServiceBusService.new
   end # def register
   
   def process(output_queue)

--- a/ELK/logstash-extension/inputs/azuretopicthreadable.rb
+++ b/ELK/logstash-extension/inputs/azuretopicthreadable.rb
@@ -38,7 +38,7 @@ class LogStash::Inputs::Azuretopicthreadable < LogStash::Inputs::Base
   
   def process(output_queue, pid)
     # Get a new instance of a service
-  	azure_service_bus = Azure::ServiceBusService.new
+  	azure_service_bus = Azure::ServiceBus::ServiceBusService.new
 	while true
 		begin
 	    # check if we have a message in the subscription

--- a/ELK/logstash-extension/inputs/azurewadtable.rb
+++ b/ELK/logstash-extension/inputs/azurewadtable.rb
@@ -30,7 +30,7 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
       config.storage_account_name = @account_name
       config.storage_access_key = @access_key
      end
-    @azure_table_service = Azure::TableService.new
+    @azure_table_service = Azure::Table::TableService.new
     @last_timestamp = @collection_start_time_utc
 	@idle_delay = @idle_delay_seconds
   end # register


### PR DESCRIPTION
Azure SDK for Ruby updated Module names:
from
Azure::BlobService
Azure::ServiceBusService
Azure::TableService

to
Azure::Blob::BlobService
Azure::ServiceBus::ServiceBusService
Azure::Table::TableService

So corresponding changes were made in the plugin Ruby scripts to use the new names.