### PR TITLE
Add missing decorate event to azurewadtable input

### DIFF
--- a/ELK/logstash-extension/inputs/azurewadtable.rb
+++ b/ELK/logstash-extension/inputs/azurewadtable.rb
@@ -91,6 +91,8 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
 		  logger.debug("pretty print end. result: " + event["EventMessage"].to_s)
 		  end
 		end
+	
+	decorate(event)
 		
         output_queue << event
       end # each block


### PR DESCRIPTION
Decorate the generated event to add properties defined in the input configuration (ex: tags)

Edit : for more information about the decorate method, see https://www.elastic.co/guide/en/logstash/current/_how_to_write_a_logstash_input_plugin.html