### PR TITLE
Adding DateTime to TypeExtensions.NotDefault

### DIFF
--- a/source/Src/SemanticLogging/Utility/TypeExtensions.cs
+++ b/source/Src/SemanticLogging/Utility/TypeExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility
             return Activator.CreateInstance(type);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "System.ComponentModel.TypeConverter.ConvertFromInvariantString(System.String)", Justification = "Converting numeri value")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "System.ComponentModel.TypeConverter.ConvertFromInvariantString(System.String)", Justification = "Converting numeric value")]
         public static object NotDefault(this Type type)
         {
             if (type == typeof(string))
@@ -33,6 +33,11 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility
             if (type == typeof(bool))
             {
                 return true;
+            }
+            
+            if (type == typeof(DateTime))
+            {
+                return DateTime.MaxValue;
             }
 
             TypeConverter tc = TypeDescriptor.GetConverter(type);

--- a/source/Tests/SemanticLogging.Tests/Utility/EventSourceAnalyzerFixture.cs
+++ b/source/Tests/SemanticLogging.Tests/Utility/EventSourceAnalyzerFixture.cs
@@ -138,6 +138,12 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Tests.Utility
             EventSourceAnalyzer.InspectAll(SemanticLoggingEventSource.Log);
         }
 
+        [TestMethod]
+        public void when_inspecting_eventSource_with_more_than_one_method_argument_use_nondefault_values()
+        {
+            EventSourceAnalyzer.InspectAll(NonDefaultArgumentValuesEventSource.Log);
+        }
+
         #region Test EventSource classes
 
         [EventSource]
@@ -370,6 +376,18 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Tests.Utility
             internal void IntMappedToEnum(int id)
             {
                 WriteEvent(1, EventKeywords.AuditFailure);
+            }
+        }
+
+        [EventSource]
+        private sealed class NonDefaultArgumentValuesEventSource : EventSource
+        {
+            internal static readonly NonDefaultArgumentValuesEventSource Log = new NonDefaultArgumentValuesEventSource();
+
+            [Event(1)]
+            public void AllValues(DateTime d, string s, Guid g, bool b)
+            {
+                WriteEvent(1, d, s, g, b);
             }
         }
 


### PR DESCRIPTION
Currently `EventSourceAnalyzer.InspectAll` fails for event sources that have a `DateTime` parameter with the following error:

```
System.FormatException: 1 is not a valid value for DateTime.
```