### PR TITLE
Add support for .NET Core in SemanticLogging, SemanticLogging.TextFile

### DIFF
--- a/source/Src/SemanticLogging.TextFile/Sinks/RollingFlatFileSink.Inner.cs
+++ b/source/Src/SemanticLogging.TextFile/Sinks/RollingFlatFileSink.Inner.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
                 {
                     // no roll will be actually performed: no timestamp pattern is available, and 
                     // the roll behavior is overwrite, so the original file will be truncated
-                    this.owner.writer.Close();
+                    this.owner.writer.Dispose();
                     File.WriteAllText(actualFileName, string.Empty);
                 }
                 else
@@ -246,7 +246,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
                     string archiveFileName = this.ComputeArchiveFileName(actualFileName, rollDateTime);
 
                     // close file
-                    this.owner.writer.Close();
+                    this.owner.writer.Dispose();
 
                     // move file
                     SafeMove(actualFileName, archiveFileName, rollDateTime);
@@ -308,7 +308,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
 
                     var actualFileName = ((FileStream)currentWriter.BaseStream).Name;
 
-                    currentWriter.Close();
+                    currentWriter.Dispose();
 
                     FileStream fileStream = null;
                     try
@@ -358,8 +358,12 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
             private static Encoding GetEncodingWithFallback()
             {
                 Encoding encoding = (Encoding)new UTF8Encoding(false).Clone();
+
+#if !CORECLR
                 encoding.EncoderFallback = EncoderFallback.ReplacementFallback;
                 encoding.DecoderFallback = DecoderFallback.ReplacementFallback;
+#endif
+
                 return encoding;
             }
 

--- a/source/Src/SemanticLogging/EventEntry.cs
+++ b/source/Src/SemanticLogging/EventEntry.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
 
             static ActivityIdPropertyAccess()
             {
-                var eventArgsType = typeof(EventWrittenEventArgs);
+                var eventArgsType = typeof(EventWrittenEventArgs).GetTypeInfo();
 
                 ActivityIdAccessor = BuildAccessor(eventArgsType.GetProperty("ActivityId"));
                 RelatedActivityIdAccessor = BuildAccessor(eventArgsType.GetProperty("RelatedActivityId"));
@@ -294,6 +294,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
 
             static ProcessPropertyAccess()
             {
+#if !CORECLR
                 if (AppDomain.CurrentDomain.IsHomogenous && AppDomain.CurrentDomain.IsFullyTrusted)
                 {
                     ProcessIdAccessor = GetCurrentProcessIdSafe;
@@ -304,6 +305,10 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
                     ProcessIdAccessor = null;
                     CurrentThreadIdAccessor = null;
                 }
+#else
+                ProcessIdAccessor = GetCurrentProcessIdSafe;
+                CurrentThreadIdAccessor = GetCurrentThreadIdSafe;
+#endif
             }
 
             public static int GetCurrentProcessId()
@@ -342,7 +347,9 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
                 }
             }
 
+#if !CORECLR
             [SuppressUnmanagedCodeSecurity]
+#endif
             [SecurityCritical]
             private static class SafeNativeMethods
             {

--- a/source/Src/SemanticLogging/EventEntry.cs
+++ b/source/Src/SemanticLogging/EventEntry.cs
@@ -12,6 +12,8 @@ using System.Runtime.InteropServices;
 using System.Security;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility;
+using System.Diagnostics;
+using System.Threading;
 
 namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
 {
@@ -326,7 +328,11 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
             {
                 try
                 {
+#if !CORECLR
                     return SafeNativeMethods.GetCurrentProcessId();
+#else
+                    return Process.GetCurrentProcess().Id;
+#endif
                 }
                 catch (SecurityException)
                 {
@@ -339,7 +345,11 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
             {
                 try
                 {
+#if !CORECLR
                     return SafeNativeMethods.GetCurrentThreadId();
+#else
+                    return Thread.CurrentThread.ManagedThreadId;
+#endif
                 }
                 catch (SecurityException)
                 {
@@ -349,7 +359,6 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
 
 #if !CORECLR
             [SuppressUnmanagedCodeSecurity]
-#endif
             [SecurityCritical]
             private static class SafeNativeMethods
             {
@@ -359,6 +368,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
                 [DllImport("kernel32.dll")]
                 public static extern int GetCurrentThreadId();
             }
+#endif
         }
     }
 }

--- a/source/Src/SemanticLogging/Formatters/XmlEventTextFormatter.cs
+++ b/source/Src/SemanticLogging/Formatters/XmlEventTextFormatter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.IO;
+using System.Reflection;
 using System.Xml;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility;
 
@@ -187,7 +188,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Formatters
             {
                 writer.WriteValue(XmlConvert.ToString((Guid)value));
             }
-            else if (valueType.IsEnum)
+            else if (valueType.GetTypeInfo().IsEnum)
             {
                 writer.WriteValue(((Enum)value).ToString("D"));
             }

--- a/source/Src/SemanticLogging/Properties/AssemblyInfo.cs
+++ b/source/Src/SemanticLogging/Properties/AssemblyInfo.cs
@@ -40,4 +40,5 @@ using System.Security;
 [assembly: InternalsVisibleTo("Microsoft.Practices.EnterpriseLibrary.SemanticLogging.InProc.Tests")]
 [assembly: InternalsVisibleTo("Microsoft.Practices.EnterpriseLibrary.SemanticLogging.OutProc.Tests")]
 [assembly: InternalsVisibleTo("Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Tests.Shared")]
+[assembly: InternalsVisibleTo("CoreCompat.SemanticLogging.TextFile")]
 #endif

--- a/source/Src/SemanticLogging/Properties/AssemblyInfo.cs
+++ b/source/Src/SemanticLogging/Properties/AssemblyInfo.cs
@@ -40,5 +40,5 @@ using System.Security;
 [assembly: InternalsVisibleTo("Microsoft.Practices.EnterpriseLibrary.SemanticLogging.InProc.Tests")]
 [assembly: InternalsVisibleTo("Microsoft.Practices.EnterpriseLibrary.SemanticLogging.OutProc.Tests")]
 [assembly: InternalsVisibleTo("Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Tests.Shared")]
-[assembly: InternalsVisibleTo("CoreCompat.SemanticLogging.TextFile")]
+[assembly: InternalsVisibleTo("CoreCompat.EnterpriseLibrary.SemanticLogging.TextFile")]
 #endif

--- a/source/Src/SemanticLogging/Properties/Resources.Designer.cs
+++ b/source/Src/SemanticLogging/Properties/Resources.Designer.cs
@@ -10,7 +10,7 @@
 
 namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Properties {
     using System;
-    
+    using System.Reflection;
     
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -39,7 +39,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/source/Src/SemanticLogging/SemanticLoggingEventSourceResources.Designer.cs
+++ b/source/Src/SemanticLogging/SemanticLoggingEventSourceResources.Designer.cs
@@ -10,6 +10,7 @@
 
 namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging {
     using System;
+    using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +41,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Practices.EnterpriseLibrary.SemanticLogging.SemanticLoggingEventSourceR" +
-                            "esources", typeof(SemanticLoggingEventSourceResources).Assembly);
+                            "esources", typeof(SemanticLoggingEventSourceResources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/source/Src/SemanticLogging/Sinks/FlushFailedException.cs
+++ b/source/Src/SemanticLogging/Sinks/FlushFailedException.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
     /// <summary>
     /// Represents an error while doing a flush operation.
     /// </summary>
+#if !CORECLR
     [Serializable]
+#endif
     public class FlushFailedException : Exception
     {
         /// <summary>Initializes a new instance of the <see cref="FlushFailedException" /> class.</summary>
@@ -40,6 +42,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
         {
         }
 
+#if !CORECLR
         /// <summary>Initializes a new instance of the System.Exception class with serialized data.</summary>
         /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
@@ -47,5 +50,6 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
             : base(info, context) 
         {
         }
+#endif
     }
 }

--- a/source/Src/SemanticLogging/Utility/FileUtil.cs
+++ b/source/Src/SemanticLogging/Utility/FileUtil.cs
@@ -71,8 +71,15 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility
             if (!Path.IsPathRooted(rootedFileName))
             {
                 // GetFullPath will resolve any relative path in rootedFileName
-                // AppDomain.CurrentDomain.BaseDirectory will be used as root to decouple from Environment.CurrentDirectory value.                
-                rootedFileName = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, rootedFileName));
+                // AppDomain.CurrentDomain.BaseDirectory will be used as root to decouple from Environment.CurrentDirectory value.
+                string baseDirectory;
+
+#if !CORECLR
+                baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+#else
+                baseDirectory = AppContext.BaseDirectory;
+#endif
+                rootedFileName = Path.GetFullPath(Path.Combine(baseDirectory, rootedFileName));
             }
 
             string directory = Path.GetDirectoryName(rootedFileName);

--- a/source/Src/SemanticLogging/project.json
+++ b/source/Src/SemanticLogging/project.json
@@ -1,7 +1,7 @@
 {
   "version": "6.0.1304-*",
 
-  "name": "CoreCompat.SemanticLogging",
+  "name": "CoreCompat.EnterpriseLibrary.SemanticLogging",
 
   "dependencies": {
     "Newtonsoft.Json": "9.0.1"

--- a/source/Src/SemanticLogging/project.json
+++ b/source/Src/SemanticLogging/project.json
@@ -2,6 +2,8 @@
   "version": "6.0.1304-*",
 
   "name": "CoreCompat.EnterpriseLibrary.SemanticLogging",
+  "title": "Enterprise Library - Semantic Logging Application Block for .NET Core",
+  "description": "The Enterprise Library Logging Application Block simplifies logging to various destinations (file, database, event log, MSMQ etc.) and tracing.",
 
   "dependencies": {
     "Newtonsoft.Json": "9.0.1"
@@ -22,7 +24,9 @@
         "System.IO.FileSystem": "4.0.1",
         "System.Reflection": "4.1.0",
         "System.Reflection.TypeExtensions": "4.1.0",
-        "System.AppContext": "4.1.0"
+        "System.AppContext": "4.1.0",
+        "System.Threading.Thread": "4.0.0",
+        "System.Diagnostics.Process": "4.1.0"
       }
     },
     "net4.5": {

--- a/source/Src/SemanticLogging/project.json
+++ b/source/Src/SemanticLogging/project.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "Newtonsoft.Json": "9.0.1"
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "buildOptions": {
+        "define": [ "CORECLR" ]
+      },
+      "dependencies": {
+        "System.Threading.Tasks.Parallel": "4.0.1",
+        "System.ComponentModel.TypeConverter": "4.1.0",
+        "System.Runtime.Serialization.Primitives": "4.1.1",
+        "System.Diagnostics.Tracing": "4.1.0",
+        "System.Console": "4.0.0",
+        "System.Diagnostics.Tools": "4.0.1",
+        "System.Runtime.InteropServices": "4.1.0",
+        "System.IO.FileSystem": "4.0.1",
+        "System.Reflection": "4.1.0",
+        "System.Reflection.TypeExtensions": "4.1.0",
+        "System.AppContext": "4.1.0"
+      }
+    },
+    "net4.5": {
+      "frameworkAssemblies": {
+        "System.Xml": "4.0.0.0",
+        "System.Xml.Linq": "4.0.0.0"
+      }
+    }
+  }
+}

--- a/source/Src/SemanticLogging/project.json
+++ b/source/Src/SemanticLogging/project.json
@@ -1,6 +1,8 @@
 {
   "version": "1.0.0-*",
 
+  "name": "CoreCompat.SemanticLogging",
+
   "dependencies": {
     "Newtonsoft.Json": "9.0.1"
   },

--- a/source/Src/SemanticLogging/project.json
+++ b/source/Src/SemanticLogging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "6.0.1304-*",
 
   "name": "CoreCompat.SemanticLogging",
 


### PR DESCRIPTION
This PR adds the (very few) changes which are required to make SemanticLogging and SemanticLogging.TextFile compile on .NET Core (tested on RC2).

The changes are backwards compatible, so the updated codebase compiles on .NET 4.5 as well.

The changes evolve around:
- The updated reflection API
- The absence of application domains
- The absence of `.Close` methods on `Stream`-related objects

Hope it helps & looking forward to use the SLAB on .NET Core!
