### PR TITLE
Added support for dynamic events.

### DIFF
--- a/source/Src/SemanticLogging/ObservableEventListener.cs
+++ b/source/Src/SemanticLogging/ObservableEventListener.cs
@@ -169,7 +169,19 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging
             EventSchema schema = null;
             try
             {
-                schema = this.schemaCache.GetSchema(eventData.EventId, eventData.EventSource);
+                if (eventData.EventId == -1)  
+                {  
+                    // Support for dynamic events introduced in .NET 4.6. Since the  
+                    // schema changes event by event, we need to generate the schema  
+                    // every time we encounter one. Caching is not possible at  
+                    // present since we have no way of ensuring that each event is  
+                    // uniquely defined (by event name).  
+                    schema = EventSourceSchemaReader.GetDynamicSchema(eventData);  
+                }  
+                else  
+                {  
+                    schema = this.schemaCache.GetSchema(eventData.EventId, eventData.EventSource);  
+                }
             }
             catch (Exception ex)
             {

--- a/source/Src/SemanticLogging/Schema/EventSchema.cs
+++ b/source/Src/SemanticLogging/Schema/EventSchema.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -15,6 +15,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
         private readonly int id;
         private readonly Guid providerId;
         private readonly string providerName;
+        private readonly string eventName;
         private readonly string[] payload;
         private readonly EventTask task;
         private readonly string taskName;
@@ -28,6 +29,9 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
         /// <summary>
         /// Initializes a new instance of the <see cref="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema.EventSchema"/> class with the specified values.
         /// </summary>
+        /// <remarks> 
+        /// This overload will cause the event name to be the concatenation of the task and operation code names. 
+        /// </remarks> 
         /// <param name="id">The event id.</param>
         /// <param name="providerId">The provider GUID.</param>
         /// <param name="providerName">The provider name.</param>
@@ -41,10 +45,32 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
         /// <param name="version">The event version.</param>
         /// <param name="payload">The event payload.</param>
         public EventSchema(int id, Guid providerId, string providerName, EventLevel level, EventTask task, string taskName, EventOpcode opcode, string opcodeName, EventKeywords keywords, string keywordsDescription, int version, IEnumerable<string> payload)
+            : this(id, providerId, providerName, taskName + opcodeName, level, task, taskName, opcode, opcodeName, keywords, keywordsDescription, version, payload)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema.EventSchema"/> class with the specified values.
+        /// </summary>
+        /// <param name="id">The event id.</param>
+        /// <param name="providerId">The provider GUID.</param>
+        /// <param name="providerName">The provider name.</param>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="level">The event level.</param>
+        /// <param name="task">The event task.</param>
+        /// <param name="taskName">The event task name.</param>
+        /// <param name="opcode">The event operation code.</param>
+        /// <param name="opcodeName">The event operation code name.</param>
+        /// <param name="keywords">The event keywords.</param>
+        /// <param name="keywordsDescription">The event keywords description.</param>
+        /// <param name="version">The event version.</param>
+        /// <param name="payload">The event payload.</param>
+        public EventSchema(int id, Guid providerId, string providerName, string eventName, EventLevel level, EventTask task, string taskName, EventOpcode opcode, string opcodeName, EventKeywords keywords, string keywordsDescription, int version, IEnumerable<string> payload)
         {
             this.id = id;
             this.providerId = providerId;
             this.providerName = providerName;
+            this.eventName = eventName;
             this.level = level;
             this.task = task;
             this.taskName = taskName;
@@ -179,13 +205,10 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
         /// <summary>
         /// Gets the name for the event.
         /// </summary>
-        /// <remarks>
-        /// This is simply the concatenation of the task and operation code names.
-        /// </remarks>
         /// <value>The event name.</value>
         public string EventName
         {
-            get { return this.TaskName + this.OpcodeName; }
+            get { return eventName; }
         }
     }
 }

--- a/source/Src/SemanticLogging/Schema/EventSourceSchemaReader.cs
+++ b/source/Src/SemanticLogging/Schema/EventSourceSchemaReader.cs
@@ -140,6 +140,11 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
         {
             // TODO: Validate that the only event id this method
             // is used for is -1 (for dynamic events)?
+            
+#warning "IMPORTANT: Please swap the following lines when the project is updated to .NET 4.6."
+            //var payloadNames = eventData.PayloadNames;
+            var payloadNames = eventData.Payload.Select(p => ""); // Workaround to allow compilation in .NET 4.5.
+
             return new EventSchema(
                             eventData.EventId,
                             eventData.EventSource.Guid,
@@ -153,7 +158,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
                             eventData.Keywords,
                             eventData.Keywords.ToString(),
                             0, // Dynamic events don't have a version.
-                            eventData.PayloadNames);
+                            payloadNames);
         }
         
         private EventLevel ParseLevel(string level)

--- a/source/Src/SemanticLogging/Schema/EventSourceSchemaReader.cs
+++ b/source/Src/SemanticLogging/Schema/EventSourceSchemaReader.cs
@@ -141,15 +141,14 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
         /// </summary>
         /// <param name="eventData">The event arguments that describe the event.</param>
         /// <returns>The event schema.</returns>
-        public static EventSchema GetDynamicSchema(EventWrittenEventArgs eventData)
+public static EventSchema GetDynamicSchema(EventWrittenEventArgs eventData)
         {
             // TODO: Validate that the only event id this method
             // is used for is -1 (for dynamic events)?
-            
-#warning "IMPORTANT: Please swap the following lines when the project is updated to .NET 4.6."
-            //var payloadNames = eventData.PayloadNames;
-            var payloadNames = eventData.Payload.Select(p => string.Empty); // Workaround to allow compilation in .NET 4.5.
 
+#warning "IMPORTANT: Please swap the following code when the project is updated to .NET 4.6."
+            /**** REPLACE BELOW ****/
+            var payloadNames = eventData.Payload.Select(p => ""); // Workaround to allow compilation in .NET 4.5.
             return new EventSchema(
                             eventData.EventId,
                             eventData.EventSource.Guid,
@@ -164,6 +163,26 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
                             eventData.Keywords.ToString(),
                             0, // Dynamic events don't have a version.
                             payloadNames);
+            /**** REPLACE ABOVE ****/
+
+            /**** ADD BELOW ****
+            return new EventSchema(
+                eventData.EventId,
+                eventData.EventSource.Guid,
+                eventData.EventSource.Name,
+                eventData.EventName,
+                eventData.Level,
+                eventData.Task,
+                eventData.Task.ToString(),
+                eventData.Opcode,
+                eventData.Opcode.ToString(),
+                ////message,
+                eventData.Keywords,
+                eventData.Keywords.ToString(),
+                0, // Dynamic events don't have a version.
+                eventData.PayloadNames);
+            **** ADD ABOVE ****/
+
         }
         
         private EventLevel ParseLevel(string level)

--- a/source/Src/SemanticLogging/Schema/EventSourceSchemaReader.cs
+++ b/source/Src/SemanticLogging/Schema/EventSourceSchemaReader.cs
@@ -136,6 +136,26 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
             return events;
         }
 
+        public static EventSchema GetDynamicSchema(EventWrittenEventArgs eventData)
+        {
+            // TODO: Validate that the only event id this method
+            // is used for is -1 (for dynamic events)?
+            return new EventSchema(
+                            eventData.EventId,
+                            eventData.EventSource.Guid,
+                            eventData.EventSource.Name,
+                            eventData.Level,
+                            eventData.Task,
+                            eventData.Task.ToString(),
+                            eventData.Opcode,
+                            eventData.Opcode.ToString(),
+                            ////message,
+                            eventData.Keywords,
+                            eventData.Keywords.ToString(),
+                            0, // Dynamic events don't have a version.
+                            eventData.PayloadNames);
+        }
+        
         private EventLevel ParseLevel(string level)
         {
             switch (level)

--- a/source/Src/SemanticLogging/Schema/EventSourceSchemaReader.cs
+++ b/source/Src/SemanticLogging/Schema/EventSourceSchemaReader.cs
@@ -136,6 +136,11 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
             return events;
         }
 
+        /// <summary>
+        /// Gets the schema for a dynamic event.
+        /// </summary>
+        /// <param name="eventData">The event arguments that describe the event.</param>
+        /// <returns>The event schema.</returns>
         public static EventSchema GetDynamicSchema(EventWrittenEventArgs eventData)
         {
             // TODO: Validate that the only event id this method
@@ -143,7 +148,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Schema
             
 #warning "IMPORTANT: Please swap the following lines when the project is updated to .NET 4.6."
             //var payloadNames = eventData.PayloadNames;
-            var payloadNames = eventData.Payload.Select(p => ""); // Workaround to allow compilation in .NET 4.5.
+            var payloadNames = eventData.Payload.Select(p => string.Empty); // Workaround to allow compilation in .NET 4.5.
 
             return new EventSchema(
                             eventData.EventId,


### PR DESCRIPTION
Support added for dynamic events introduced in .NET 4.6. Since the project is currently compiled against 4.5, the payload names are not made available in the schema at this time. A warning has been added indicating what needs to be done when the project is upgraded to 4.6 to support payload names. This addresses issue #44, and partially addresses #64.
