### PR TITLE
Adding byte[] to TypeExtensions.Default and TypeExtensions.NotDefault

### DIFF
--- a/source/Src/SemanticLogging/Utility/TypeExtensions.cs
+++ b/source/Src/SemanticLogging/Utility/TypeExtensions.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility
                 return string.Empty;
             }
 
+            if (type == typeof(byte[]))
+            {
+                return new byte[] { };
+            }
+
             return Activator.CreateInstance(type);
         }
 
@@ -38,6 +43,11 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility
             if (type == typeof(DateTime))
             {
                 return DateTime.MaxValue;
+            }
+
+            if (type == typeof(byte[]))
+            {
+                return new byte[] { 1, 2, 3 };
             }
 
             TypeConverter tc = TypeDescriptor.GetConverter(type);

--- a/source/Tests/SemanticLogging.Tests/Utility/EventSourceAnalyzerFixture.cs
+++ b/source/Tests/SemanticLogging.Tests/Utility/EventSourceAnalyzerFixture.cs
@@ -385,9 +385,9 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Tests.Utility
             internal static readonly NonDefaultArgumentValuesEventSource Log = new NonDefaultArgumentValuesEventSource();
 
             [Event(1)]
-            public void AllValues(DateTime d, string s, Guid g, bool b)
+            public void AllValues(byte[] ba, DateTime d, string s, Guid g, bool b)
             {
-                WriteEvent(1, d, s, g, b);
+                WriteEvent(1, ba, d, s, g, b);
             }
         }
 


### PR DESCRIPTION
Currently `EventSourceAnalyzer.InspectAll` fails for event sources that have a `byte[]` parameter with the following error:

```
System.MissingMethodException: No parameterless constructor defined for this object.
```
